### PR TITLE
Add a condition to ignore all empty values parsed

### DIFF
--- a/lib/fluent/plugin/parser_kv.rb
+++ b/lib/fluent/plugin/parser_kv.rb
@@ -19,7 +19,9 @@ module Fluent
         record = {}
         text.split(@kv_delimiter).each do |kv|
           k, v = kv.split(@kv_char, 2)
+          unless  v.nil? || v == ""
           record[k] = v
+          end
         end
 
         convert_field_type!(record) if @type_converters


### PR DESCRIPTION
I've just added an "if" condition because during my tests I got a lot of keys with empty/nil values (and then it generates errors when forwarding to elasticsearch) 

Here is a sample for example :  
[...] cardHolderBithDate=|refArchivage=L15823587901||canalPaiement=E_COMMERCE_RECURRENT 

Before modification, the kv-parser gives  : 
{
[...]
cardHolderBithDate : ""
refArchivage : "L15823587901"
"" : null 
canalPaiement : "E_COMMERCE_RECURRENT"
}

After modification, the kv-parser gives  : 
{
[...]
refArchivage : "L15823587901"
canalPaiement : "E_COMMERCE_RECURRENT"
}
