### PR TITLE
Supports a string containing spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+Gemfile.lock
+
+pkg/
+.idea/

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ gives
 
 ## Parameters
 
-* **kv_delimiter**: The delimiter for key-value pairs. By default, it is the regexp `/\t\s/+` (one or more whitespace/tabs). If the value starts and ends with the character `'/'`, the separator is interpreted to be a regexp. Else, it is interpreted to be a string. Hence,
+* **kv_delimiter**: The delimiter for key-value pairs. By default `\t\s` (one or more whitespace/tabs).
     
-    - `kv_delimiter /a+/` splits on one or more "a"s
-    - `kv_delimiter a` splits on a single "a"
+    - `kv_delimiter a` splits on one or more "a"s
+    - `kv_delimiter ab` splits on one or more "a"s or "b"s
 
 * **kv_char**: The string to split the key from the value. By default, it is "=".
 * **time_key**: The time key field among the key-value pairs to be used as the time for the event. If missing or unparsable, the current time is used.

--- a/fluent-plugin-kv-parser.gemspec
+++ b/fluent-plugin-kv-parser.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-kv-parser"
-  spec.version       = "0.0.1"
+  spec.version       = "0.0.2"
   spec.description   = 'Fluentd parser plugin to parse key value pairs'
   spec.authors       = ["kiyoto"]
   spec.email         = ["kiyoto@treasure-data.com"]
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", '~> 1.7'
-  spec.add_development_dependency "rake", '~> 10.1'
-  spec.add_runtime_dependency "fluentd", '~> 0.10'
+  spec.add_development_dependency "bundler", '~> 1.14.6'
+  spec.add_development_dependency "rake", '~> 11.1.2'
+  spec.add_runtime_dependency "fluentd", ['>= 0.10.0', '< 0.14.0']
 end

--- a/test/test_kv_parser.rb
+++ b/test/test_kv_parser.rb
@@ -33,16 +33,16 @@ module ParserTest
 
     def test_with_time
       d = create_driver({"types" => "time:time"})
-      d.instance.parse("k1=foo time=1970-01-01T01:00:00") {|time, v|
-        assert_equal(-28800, time)
+      d.instance.parse("k1=foo time=1970-01-01T01:00:00Z") {|time, v|
+        assert_equal(3600, time)
         assert_equal("foo", v["k1"])
       }
     end
 
     def test_with_custom_time_key
       d = create_driver({"time_key" => "my_time", "types" => "my_time:time"})
-      d.instance.parse("k1=foo my_time=1970-01-01T01:00:00") {|time, v|
-        assert_equal(-28800, time)
+      d.instance.parse("k1=foo my_time=1970-01-01T01:00:00Z") {|time, v|
+        assert_equal(3600, time)
         assert_equal("foo", v["k1"])
       }
     end

--- a/test/test_kv_parser.rb
+++ b/test/test_kv_parser.rb
@@ -8,54 +8,59 @@ module ParserTest
   class KVParserTest < ::Test::Unit::TestCase
     include ParserTest
 
+    def create_driver(conf)
+      Fluent::Test::ParserTestDriver.new(Fluent::TextParser::KVParser).configure(conf)
+    end
+
     def test_basic
-      parser = Fluent::TextParser::KVParser.new
-      parser.configure
-      parser.parse("k1=v1 k2=v2") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
-      parser.parse("k1=v1    k2=v2") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
-      parser.parse("k2=v2 k1=v1") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
-      parser.parse("k2=v2\tk1=v1") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
-      parser.parse("k2=v2\t k1=v1") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
+      d = create_driver({})
+      d.instance.parse("k1=v1 k2=v2") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
+      d.instance.parse("k1=v1    k2=v2") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
+      d.instance.parse("k2=v2 k1=v1") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
+      d.instance.parse("k2=v2\tk1=v1") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
+      d.instance.parse("k2=v2\t k1=v1") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
+      d.instance.parse("k2=v2\t \t k1=v1") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
+      d.instance.parse("k1=\"v 1\"") {|_, v| assert_equal({"k1"=>"v 1"}, v)}
+      d.instance.parse("k1=\"v 1\" k2=\"v 2\"") {|_, v| assert_equal({"k1"=>"v 1", "k2"=>"v 2"}, v)}
+      d.instance.parse("\"k 1\"=\"v 1\" \"k 2\"=\"v 2\"") {|_, v| assert_equal({"k 1"=>"v 1", "k 2"=>"v 2"}, v)}
+      d.instance.parse("\"k 1\"=\"v \\\"1\\\"\" \"k 2\"=\"v \\\"2\\\"\"") {|_, v| assert_equal({"k 1"=>"v \\\"1\\\"", "k 2"=>"v \\\"2\\\""}, v)}
     end
 
     def test_with_types
-      parser = Fluent::TextParser::KVParser.new
-      parser.configure("types" => "k1:integer")
-      parser.parse("k1=100") {|_, v| assert_equal(100, v["k1"])}
+      d = create_driver({"types" => "k1:integer"})
+      d.instance.parse("k1=100") {|_, v| assert_equal(100, v["k1"])}
     end
 
     def test_with_time
-      parser = Fluent::TextParser::KVParser.new
-      parser.configure("types" => "time:time")
-      parser.parse("k1=foo time=1970-01-01T01:00:00") {|time, v|
-        assert_equal(3600, time)
+      d = create_driver({"types" => "time:time"})
+      d.instance.parse("k1=foo time=1970-01-01T01:00:00") {|time, v|
+        assert_equal(-28800, time)
         assert_equal("foo", v["k1"])
       }
     end
 
     def test_with_custom_time_key
-      parser = Fluent::TextParser::KVParser.new
-      parser.configure("time_key" => "my_time", "types" => "my_time:time")
-      parser.parse("k1=foo my_time=1970-01-01T01:00:00") {|time, v|
-        assert_equal(3600, time)
+      d = create_driver({"time_key" => "my_time", "types" => "my_time:time"})
+      d.instance.parse("k1=foo my_time=1970-01-01T01:00:00") {|time, v|
+        assert_equal(-28800, time)
         assert_equal("foo", v["k1"])
       }
     end
 
     def test_custom_delimiter
-      parser = Fluent::TextParser::KVParser.new
-      parser.configure("kv_delimiter" => "|")
-      parser.parse("k1=v1|k2=v2") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
-      parser.configure("kv_delimiter" => "/[@ ]/")
-      parser.parse("k1=v1@k2=v2 k3=v3") {|_, v|
+      d = create_driver({"kv_delimiter" => "|"})
+      d.instance.parse("k1=v1|k2=v2") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
+      d.instance.parse("k1=v1||k2=v2") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
+
+      d = create_driver({"kv_delimiter" => "@ "})
+      d.instance.parse("k1=v1@k2=v2 k3=v3") {|_, v|
         assert_equal({"k1"=>"v1", "k2"=>"v2", "k3"=>"v3"}, v)
       }
     end
 
     def test_custom_kv_char
-      parser = Fluent::TextParser::KVParser.new
-      parser.configure("kv_char" => "#")
-      parser.parse("k1#v1 k2#v2") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
+      d = create_driver({"kv_char" => "#"})
+      d.instance.parse("k1#v1 k2#v2") {|_, v| assert_equal({"k1"=>"v1", "k2"=>"v2"}, v)}
     end
 
     def test_types_param


### PR DESCRIPTION
I would like to support strings containing spaces.

config

```
<filter kvp.**>
  @type parser
  format kv
  key_name message
  reserve_data yes
  types time:time
</filter>
```

input

```
time=2017-05-27T04:57:34Z level=info msg="test message containing spaces."
```

output

```
{
	"message": "time=2017-05-27T04:57:34Z level=info msg=\"test message containing spaces.\"",
	"level": "info",
	"msg": "test message containing spaces."
}
```

Could you consider this pull request?
Thanks.